### PR TITLE
Updated phoenixframework links and use secure url

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,12 @@ To start your Phoenix app:
 
 Now you can visit [`localhost:4000`](http://localhost:4000) from your browser.
 
-Ready to run in production? Please [check our deployment guides](http://www.phoenixframework.org/docs/deployment).
+Ready to run in production? Please [check our deployment guides](https://hexdocs.pm/phoenix/deployment.html).
 
 ## Learn more
 
-  * Official website: http://www.phoenixframework.org/
-  * Guides: http://phoenixframework.org/docs/overview
-  * Docs: https://hexdocs.pm/phoenix
-  * Mailing list: http://groups.google.com/group/phoenix-talk
+  * Official website: https://phoenixframework.org/
+  * Guides: https://hexdocs.pm/phoenix/overview.html
+  * Docs: https://hexdocs.pm/phoenix/Phoenix.html
+  * Mailing list: https://groups.google.com/forum/#!forum/phoenix-talk
   * Source: https://github.com/phoenixframework/phoenix


### PR DESCRIPTION
A few Phoenix Framework urls redirect to the new hexdocs page.